### PR TITLE
add possibility to force window onload

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 
-export default class VLibras extends Component {
+export default class VLibras extends Component<{ forceOnload?: boolean }> {
   widgetSrc: string
   scriptSrc: string
   script: any
@@ -18,6 +18,10 @@ export default class VLibras extends Component {
     this.script.onload = (load: any) => {
       // @ts-ignore
       new window.VLibras.Widget(this.widgetSrc)
+      if (this.props.forceOnload) {
+        // @ts-ignore
+        window.onload()
+      }
     }
     document.head.appendChild(this.script)
   }


### PR DESCRIPTION
Meu problema: minha aplicação precisa consultar um banco de dados externo para verificar se precisa colocar o VLibras na tela, essa consulta é feita de forma assincrona, o que faz com que eu só tenha essa resposta depois que a página inteira já foi carregada.

Isso significa que o bootstrap do VLibras não roda pois ele é adicionado no window.onload (chamando o construtor de window.VLibras.Widget) e o window.onload já foi executado.

Minha proposta (testada em meu ambiente e aplicação), é que adicionemos uma prop para o componente, para que, assim que o script seja carregado, possamos chamar o window.onload, adicionando assim o VLibras à tela.

O cenário ideal aqui seria o próprio VLibras exportar uma função que inicialize o componente (algo como window.VLibras.init), ao invés de apenas fazer isso no window.onload, porém isso dependeria de um desenvolvimento do gov, hehe.